### PR TITLE
Added card set index page and index button for all sub pages

### DIFF
--- a/card_inventory/templates/card_details.html
+++ b/card_inventory/templates/card_details.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% block page_content %}
+    <a href="../"><input type="button" value="Index" class="btn btn-primary" /></a>
     <h1>{{ set_name }}</h1>
     <table class='table table-striped table-hover'>
         <thead class='thead-dark'>

--- a/card_inventory/templates/sets_index.html
+++ b/card_inventory/templates/sets_index.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block page_content %}
+    {% for set in sets %}
+        <a href='{{ set.set_link }}' class='btn btn-primary list-group-item active' role='button' aria-pressed='true'>{{ set.set_name }}</a>
+    {% endfor %}
+{% endblock %}

--- a/card_inventory/urls.py
+++ b/card_inventory/urls.py
@@ -3,5 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('', views.sets_index, name='sets_index'),
     path('<str:set_name>/', views.card_details_by_set, name='card_details')
 ]

--- a/card_inventory/views.py
+++ b/card_inventory/views.py
@@ -2,6 +2,16 @@ from django.shortcuts import render
 
 from card_inventory.models import Cards
 
+def sets_index(request):
+    # Get all unique set names
+    sets = Cards.objects.order_by().values('set_name').distinct()
+
+    # Transform each set name into a link and save as a dictionary item
+    for s in sets:
+        s['set_link'] = s['set_name'].replace(' ', '_').lower()
+
+    return render(request, 'sets_index.html', {'sets': sets})
+
 def card_details_by_set(request, set_name):
     set_name_clean = set_name.replace('_', ' ').title()
     cards = Cards.objects.filter(set_name=set_name_clean)


### PR DESCRIPTION
Relates to: #10 

Added an index page for all sets. It lists all available sets and links to their respective subpages. This page is located at the app's base url `card_inventory`.
<img width="704" alt="Screen Shot 2020-09-01 at 9 20 00 PM" src="https://user-images.githubusercontent.com/46981564/91928299-ec306480-ec98-11ea-8678-ffbae6298573.png">

Added an `Index` button to each set set details page that directs back to the app's base url `card_inventory`.
<img width="707" alt="Screen Shot 2020-09-01 at 9 21 10 PM" src="https://user-images.githubusercontent.com/46981564/91928361-14b85e80-ec99-11ea-8e52-605d1bf20032.png">

