### PR TITLE
Removed unnecessarily altering the set_name data for request calls.

### DIFF
--- a/card_inventory/views.py
+++ b/card_inventory/views.py
@@ -8,12 +8,12 @@ def sets_index(request):
 
     # Transform each set name into a link and save as a dictionary item
     for s in sets:
-        s['set_link'] = s['set_name'].replace(' ', '_').lower()
+        s['set_link'] = s['set_name'].replace(' ', '_')
 
     return render(request, 'sets_index.html', {'sets': sets})
 
 def card_details_by_set(request, set_name):
-    set_name_clean = set_name.replace('_', ' ').title()
+    set_name_clean = set_name.replace('_', ' ')
     cards = Cards.objects.filter(set_name=set_name_clean)
 
     return render(request, 'card_details.html',


### PR DESCRIPTION
Closes #12 

All links for every set name link properly to their description pages.

The URL patterns are now the set names with underscores instead of spaces.

Example for Shining Legends:
- Previously the url pattern was `/shining_legends/` with the DB call being `Shining Legends`.
- Now the url pattern is `/Shining_Legends/` with the DB call being `Shining Legends`.