### PR TITLE
Added Navbar to all pages in the `card_inventory` app.

### DIFF
--- a/card_inventory/templates/base.html
+++ b/card_inventory/templates/base.html
@@ -3,22 +3,40 @@
 <html>
     <head>
         <!-- Required meta tags -->
-        <meta charset="utf-8">
-        <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+        <meta charset='utf-8'>
+        <meta name='viewport' content='width=device-width, initial-scale=1, shrink-to-fit=no'>
 
         <!-- Bootstrap CSS -->
-        <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+        <link rel='stylesheet' href='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css' integrity='sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T' crossorigin='anonymous'>
 
     </head>
     <body>
+        <!-- Header -->
+        <nav class='navbar navbar-expand-lg navbar-light bg-light'>
+            <button class='navbar-toggler' type='button' data-toggle='collapse' data-target='#navbarTogglerDemo03' aria-controls='navbarTogglerDemo03' aria-expanded='false' aria-label='Toggle navigation'>
+                <span class='navbar-toggler-icon'></span>
+            </button>
+
+            <a class='navbar-brand' href=''>{% block navbar_title %}{% endblock %}</a>
+
+            <div class='collapse navbar-collapse' id='navbarTogglerDemo03'>
+                <ul class='navbar-nav mr-auto mt-2 mt-lg-0'>
+                    {% block navbar_dropdown %}
+                    {% endblock %}
+                </ul>
+            </div>
+        </nav>
+
+
+        <!-- Page Content-->
         {% block page_content %}
         {% endblock %}
 
         <!-- Optional JavaScript -->
         <!-- jQuery first, then Popper.js, then Bootstrap JS -->
-        <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-        <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+        <script src='https://code.jquery.com/jquery-3.3.1.slim.min.js' integrity='sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo' crossorigin='anonymous'></script>
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js' integrity='sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1' crossorigin='anonymous'></script>
+        <script src='https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js' integrity='sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM' crossorigin='anonymous'></script>
 
     </body>
 </html>

--- a/card_inventory/templates/sets_index.html
+++ b/card_inventory/templates/sets_index.html
@@ -1,7 +1,14 @@
-{% extends "base.html" %}
+{% extends 'base.html' %}
+
+{% block navbar_title %} {{ title }} {% endblock %}
+
+{% block navbar_dropdown %}
+    {% for set in sets %}
+        <li class='nav-item'>
+            <a href='{{ set.set_link }}' class='nav-link'>{{ set.set_name }}</a>
+        </li>
+    {% endfor %}
+{% endblock %}
 
 {% block page_content %}
-    {% for set in sets %}
-        <a href='{{ set.set_link }}' class='btn btn-primary list-group-item active' role='button' aria-pressed='true'>{{ set.set_name }}</a>
-    {% endfor %}
 {% endblock %}

--- a/card_inventory/views.py
+++ b/card_inventory/views.py
@@ -10,7 +10,9 @@ def sets_index(request):
     for s in sets:
         s['set_link'] = s['set_name'].replace(' ', '_')
 
-    return render(request, 'sets_index.html', {'sets': sets})
+    return render(request, 'sets_index.html',
+        {'title':'PTCG Sets',
+         'sets': sets})
 
 def card_details_by_set(request, set_name):
     set_name_clean = set_name.replace('_', ' ')


### PR DESCRIPTION
- Changed all instances of `"` to `'` for consistency.
- Added generic navbar that can be personalized per page using the
  `navbar_title` and `navbar_dropdown` blocks.
- Generalized the `sets_index` page so that all card set links are
  contained within the dropdown menu.
- Added `title` response within the `sets_index` model for use by
  the `navbar_title` block within the HTML file.

Closes #15 

Verified that the webpage renders as desired. The navbar dropdown menu contains all the links that were previously buttons. The navbar title is consistent with the render of `views.sets_index`.
<img width="898" alt="Screen Shot 2020-09-02 at 7 52 38 PM" src="https://user-images.githubusercontent.com/46981564/92062411-ec426a00-ed55-11ea-838c-6da53f4abd4a.png">
