### PR TITLE
Set display Improvements.

### DIFF
--- a/card_inventory/templates/base.html
+++ b/card_inventory/templates/base.html
@@ -22,7 +22,7 @@
             <div class='collapse navbar-collapse' id='navbarTogglerDemo03'>
                 <ul class='navbar-nav mr-auto mt-2 mt-lg-0'>
                     <li class='nav-item'>
-                        <a href='../' class='nav-link'>Index</a>
+                        <a href='/' class='nav-link'>Index</a>
                     </li>
                 </ul>
             </div>

--- a/card_inventory/templates/base.html
+++ b/card_inventory/templates/base.html
@@ -21,8 +21,9 @@
 
             <div class='collapse navbar-collapse' id='navbarTogglerDemo03'>
                 <ul class='navbar-nav mr-auto mt-2 mt-lg-0'>
-                    {% block navbar_dropdown %}
-                    {% endblock %}
+                    <li class='nav-item'>
+                        <a href='../' class='nav-link'>Index</a>
+                    </li>
                 </ul>
             </div>
         </nav>

--- a/card_inventory/templates/cards_by_set.html
+++ b/card_inventory/templates/cards_by_set.html
@@ -1,11 +1,5 @@
 {% extends "base.html" %}
 
-{% block navbar_dropdown %}
-    <li class='nav-item'>
-            <a href='../' class='nav-link'>Index</a>
-    </li>
-{% endblock %}
-
 {% block page_content %}
     <h1>{{ set_name }}</h1>
     <table class='table table-striped table-hover'>

--- a/card_inventory/templates/sets_index.html
+++ b/card_inventory/templates/sets_index.html
@@ -5,11 +5,11 @@
     <div class='row'>
         {% for set in sets %}
             <div class='col' style='padding-bottom: 2rem;'>
-                <div class='card' style='width: 20rem; height: 32rem; padding-bottom: 2rem; padding-top: 2rem;'>
-                    <div style='min-height: 14rem;'>
-                        <img src='{{ set.logo_url }}' class='card-img-top' style='width: 18rem; height: auto; padding-top: 2rem; padding-left: 2rem; padding-bottom: 2rem;'>
+                <div class='card' style='width: 22rem; height: 40rem; padding-bottom: 2rem; padding-top: 2rem;'>
+                    <div style='height: 22rem; width: 22rem; text-align: center;'>
+                        <img src='{{ set.logo_url }}' class='card-img-top' style='width: 22rem; height: auto; object-fit: scale-down; padding-left: 1rem;padding-right: 1rem;'>
                     </div>
-                    <div class='card-body'>
+                    <div class='card-body' style='padding-top: 2rem;'>
                         <div class='container'>
                             <div class='row'>
                                 <div class='col'>
@@ -18,9 +18,26 @@
                                 <div class='col'>
                                     <h5 class='card-title'>{{ set.name }}</h5>
                                     <p class='card-text'>Release Date {{ set.release_date }}</p>
+                                </div>
+                            </div>
+                            <div class='row'>
+                                <div class='col'>
+                                    <div class='rounded-circle border' style='height: 4rem; width: 4rem; display: flex; align-items: center; justify-content: center;'>
+                                        <p class='card-text'>{{ set.quantity_normal }}</p>
+                                    </div>
+                                </div>
+                                <div class='col'>
+                                    <div class='rounded-circle border' style='height: 4rem; width: 4rem; display: flex; align-items: center; justify-content: center;'>
+                                        <p class='card-text'>{{ set.quantity_reverse }}</p>
+                                    </div>
+                                </div>
+                                <div class='col'>
+                                    <div class='rounded-circle border' style='height: 4rem; width: 4rem; display: flex; align-items: center; justify-content: center;'>
+                                        <p class='card-text'>{{ set.quantity_holo }}</p>
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                    </div>
                         <a href='{{ set.link }}' class='stretched-link'></a>
                     </div>
                 </div>

--- a/card_inventory/templates/sets_index.html
+++ b/card_inventory/templates/sets_index.html
@@ -5,9 +5,9 @@
     <div class='row'>
         {% for set in sets %}
             <div class='col' style='padding-bottom: 2rem;'>
-                <div class='card' style='width: 18rem; height: 32rem; padding-bottom: 2rem; padding-top: 2rem;'>
+                <div class='card' style='width: 20rem; height: 32rem; padding-bottom: 2rem; padding-top: 2rem;'>
                     <div style='min-height: 14rem;'>
-                        <img src='{{ set.logo_url }}' class='card-img-top' style='width: 16rem; height: auto; padding-top: 2rem; padding-left: 2rem; padding-bottom: 2rem;'>
+                        <img src='{{ set.logo_url }}' class='card-img-top' style='width: 18rem; height: auto; padding-top: 2rem; padding-left: 2rem; padding-bottom: 2rem;'>
                     </div>
                     <div class='card-body'>
                         <div class='container'>

--- a/card_inventory/templates/sets_index.html
+++ b/card_inventory/templates/sets_index.html
@@ -1,12 +1,34 @@
 {% extends 'base.html' %}
 
 {% block navbar_dropdown %}
-    {% for set in sets %}
-        <li class='nav-item'>
-            <a href='{{ set.set_link }}' class='nav-link'>{{ set.set_name }}</a>
-        </li>
-    {% endfor %}
 {% endblock %}
 
 {% block page_content %}
+<div class='container-fluid'>
+    <div class='row'>
+        {% for set in sets %}
+            <div class='col' style='padding-bottom: 2rem;'>
+                <div class='card' style='width: 18rem; height: 32rem; padding-bottom: 2rem; padding-top: 2rem;'>
+                    <div style='min-height: 14rem;'>
+                        <img src='{{ set.logo_url }}' class='card-img-top' style='width: 16rem; height: auto; padding-top: 2rem; padding-left: 2rem; padding-bottom: 2rem;'>
+                    </div>
+                    <div class='card-body'>
+                        <div class='container'>
+                            <div class='row'>
+                                <div class='col'>
+                                    <img src='{{ set.symbol_url }}' style='width: auto; height: 3rem; align-self: center; padding-top: 1rem;'>
+                                </div>
+                                <div class='col'>
+                                    <h5 class='card-title'>{{ set.name }}</h5>
+                                    <p class='card-text'>Release Date {{ set.release_date }}</p>
+                            </div>
+                        </div>
+                    </div>
+                        <a href='{{ set.link }}' class='stretched-link'></a>
+                    </div>
+                </div>
+            </div>
+        {% endfor %}
+    </div>
+</div>
 {% endblock %}

--- a/card_inventory/templates/sets_index.html
+++ b/card_inventory/templates/sets_index.html
@@ -1,8 +1,5 @@
 {% extends 'base.html' %}
 
-{% block navbar_dropdown %}
-{% endblock %}
-
 {% block page_content %}
 <div class='container-fluid'>
     <div class='row'>

--- a/card_inventory/views.py
+++ b/card_inventory/views.py
@@ -1,14 +1,13 @@
 from django.shortcuts import render
+import pokemontcgsdk
 
 from card_inventory.models import Cards
 
 def sets_index(request):
-    # Get all unique set names
-    sets = Cards.objects.order_by().values('set_name').distinct()
-
-    # Transform each set name into a link and save as a dictionary item
-    for s in sets:
-        s['set_link'] = s['set_name'].replace(' ', '_')
+    sets = [{'name': Set.name, 'link': Set.name.replace(' ', '_'),
+             'series': Set.series, 'release_date': Set.release_date,
+             'logo_url': Set.logo_url, 'symbol_url': Set.symbol_url}
+            for Set in pokemontcgsdk.Set.all()]
 
     return render(request, 'sets_index.html', {'sets': sets})
 

--- a/card_inventory/views.py
+++ b/card_inventory/views.py
@@ -9,6 +9,18 @@ def sets_index(request):
              'logo_url': Set.logo_url, 'symbol_url': Set.symbol_url}
             for Set in pokemontcgsdk.Set.all()]
 
+    for s in sets:
+        try:
+            quantity_normal = sum([card.quantity_normal for card in Cards.objects.filter(set_name=s['name'])])
+            quantity_reverse = sum([card.quantity_reverse for card in Cards.objects.filter(set_name=s['name'])])
+            quantity_holo = sum([card.quantity_holo for card in Cards.objects.filter(set_name=s['name'])])
+        except:
+            quantity_normal, quantity_reverse, quantity_holo = None, None, None
+
+        s['quantity_normal'] = quantity_normal
+        s['quantity_reverse'] = quantity_reverse
+        s['quantity_holo'] = quantity_holo
+
     return render(request, 'sets_index.html', {'sets': sets})
 
 def cards_by_set(request, set_name):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.2.10
 dj-database-url==0.5.0
 Django==3.1
 gunicorn==20.0.4
+pokemontcgsdk==2.0.0
 psycopg2==2.8.5
 pytz==2020.1
 sqlparse==0.3.1


### PR DESCRIPTION
- Changed the dropdown menu to be consistent across all app pages. Currently, there is only one link the the set index.
- Set information is now displayed on the set index page itself. For each set, this information includes:
    - the set's title image,
    - the set's logo image,
    - the set's title,
    - the set's release date, and
    - the set's currently-owned quantities (normal, reverse, and holo from left to right in the "bubbles").

These cards are displayed inline on the page at a set height and width for consistency. 

An example of this view is as follows:

<img width="1733" alt="Screen Shot 2020-09-03 at 3 12 52 PM" src="https://user-images.githubusercontent.com/46981564/92171551-af7b7f00-edf8-11ea-9625-7d55fb6ad54e.png">
