### PR TITLE
Display Card Images within `cards_by_set` View

### DIFF
--- a/card_inventory/templates/cards_by_set.html
+++ b/card_inventory/templates/cards_by_set.html
@@ -5,6 +5,7 @@
     <table class='table table-striped table-hover'>
         <thead class='thead-dark'>
             <tr>
+                <th scope='col'>Card Image</th>
                 <th scope='col'>Card Number</th>
                 <th scope='col'>Card Name</th>
                 <th scope='col'>Normal</th>
@@ -15,7 +16,8 @@
         <tbody>
             {% for card in cards %}
                 <tr>
-                    <th scope='row'>{{ card.card_number }}/{{ set_info.max_cards }}</th>
+                    <th><img src='https://images.pokemontcg.io/{{ card.set_code.set_code }}/{{ card.card_number }}.png'></th>
+                    <th>{{ card.card_number }}/{{ set_info.max_cards }}</th>
                     <td>{{ card.card_name }}</td>
                     <td>{{ card.quantity_normal }}</td>
                     <td>{{ card.quantity_reverse }}</td>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a column to the `cards_by_set` view to display the card images pulled dynamically from the pokemontcgsdk API.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #43 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will set-up a more visual representation of my current card collection. It helps break up the information into a more visually pleasing manner than just text.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually as well as within the current tests.

## Screenshots (if appropriate):
The dynamic image display in action:
<img width="890" alt="Screen Shot 2020-09-29 at 5 29 47 PM" src="https://user-images.githubusercontent.com/46981564/94627360-912f6480-027a-11eb-964e-839d1b46cb3b.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.